### PR TITLE
Use sassdoc-extras; add default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,17 @@
+{
+  "display": {
+    "annotations": {
+      "function": ["description", "parameter", "return", "example", "throw", "require", "usedby", "since", "see", "todo", "link", "author"],
+      "mixin": ["description", "parameter", "content", "example", "output", "throw", "require", "usedby", "since", "see", "todo", "link", "author"],
+      "placeholder": ["description", "example", "throw", "require", "usedby", "since", "see", "todo", "link", "author"],
+      "variable": ["description", "type", "property", "require", "example", "usedby", "since", "see", "todo", "link", "author"],
+      "css": ["description", "example", "since", "see", "todo", "link", "author"]
+    },
+    "access": ["public", "private"],
+    "alias": false,
+    "watermark": true
+  },
+  "groups": {
+    "undefined": "General"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -56,11 +56,17 @@ var theme = themeleon(__dirname, function (t) {
  * configuration.
  */
 module.exports = function (dest, ctx) {
+  if (!('view' in ctx)) {
+    ctx.view = {}
+  }
   var def = require('./default.json');
 
   // Apply default values for groups and display.
   ctx.groups = extend(def.groups, ctx.groups);
   ctx.display = extend(def.display, ctx.display);
+
+  // Extend default `view.json` with `ctx.view` object
+  ctx.view = extend(require('./view.json'), ctx.view)
 
   // Extend top-level context keys.
   ctx = extend({}, def, ctx);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 /**
- * Themeleon template helper, using the Swig module.
+ * Themeleon template helper, using consolidate.js module.
  *
  * See <https://github.com/themeleon/themeleon>.
- * See <https://github.com/themeleon/themeleon-swig>.
+ * See <https://github.com/tj/consolidate.js>.
  */
-var themeleon = require('themeleon')().use('swig')
+var themeleon = require('themeleon')().use('consolidate');
 
 /**
  * SassDoc filters (providing Markdown and other helpers).
@@ -46,6 +46,9 @@ var theme = themeleon(__dirname, function (t) {
   /**
    * Render `views/index.html.swig` with the theme's context (`ctx` below)
    * as `index.html` in the destination directory.
+   *
+   * We use Swig which is provided by consolidate.js, but many other
+   * template engines are available for you to use.
    */
   t.swig('views/index.html.swig', 'index.html')
 })

--- a/index.js
+++ b/index.js
@@ -7,18 +7,12 @@
 var themeleon = require('themeleon')().use('consolidate');
 
 /**
- * SassDoc filters (providing Markdown and other helpers).
+ * SassDoc extras (providing Markdown and other filters, and different way to
+ * index SassDoc data).
  *
- * See <https://github.com/SassDoc/sassdoc-filter>.
+ * See <https://github.com/SassDoc/sassdoc-extras>.
  */
-var filter = require('sassdoc-filter')
-
-/**
- * SassDoc indexer module, to index data with a certain granularity.
- *
- * See <https://github.com/SassDoc/sassdoc-indexer>.
- */
-var indexer = require('sassdoc-indexer')
+var extras = require('sassdoc-extras');
 
 /**
  * Utility function we will use to merge a default configuration
@@ -62,12 +56,14 @@ var theme = themeleon(__dirname, function (t) {
  * configuration.
  */
 module.exports = function (dest, ctx) {
-  if (!('view' in ctx)) {
-    ctx.view = {}
-  }
+  var def = require('./default.json');
 
-  // Extend default `view.json` with `ctx.view` object
-  ctx.view = extend(require('./view.json'), ctx.view)
+  // Apply default values for groups and display.
+  ctx.groups = extend(def.groups, ctx.groups);
+  ctx.display = extend(def.display, ctx.display);
+
+  // Extend top-level context keys.
+  ctx = extend({}, def, ctx);
 
   /**
    * Parse text data (like descriptions) as Markdown, and put the
@@ -76,9 +72,9 @@ module.exports = function (dest, ctx) {
    * For example, `ctx.package.description` will be parsed as Markdown
    * in `ctx.package.htmlDescription`.
    *
-   * See <https://github.com/SassDoc/sassdoc-filter#markdown>.
+   * See <http://sassdoc.com/extra-tools/#markdown>.
    */
-  filter.markdown(ctx)
+  extras.markdown(ctx);
 
   /**
    * Add a `display` property for each data item regarding of display
@@ -94,9 +90,9 @@ module.exports = function (dest, ctx) {
    *       }
    *     }
    *
-   * See <https://github.com/SassDoc/sassdoc-filter#display>.
+   * See <http://sassdoc.com/extra-tools/#display-toggle>.
    */
-  // filter.display(ctx)
+  //extras.display(ctx);
 
   /**
    * Allow the user to give a name to the documentation groups.
@@ -106,9 +102,9 @@ module.exports = function (dest, ctx) {
    *
    * **Note:** all items without a group are in the `undefined` group.
    *
-   * See <https://github.com/SassDoc/sassdoc-filter#group-name>.
+   * See <http://sassdoc.com/extra-tools/#groups-aliases>.
    */
-  // filter.groupName(ctx)
+  //extras.groupName(ctx);
 
   /**
    * Use SassDoc indexer to index the data by group and type, so we
@@ -130,7 +126,7 @@ module.exports = function (dest, ctx) {
    * You can then use `data.byGroupAndType` instead of `data` in your
    * templates to manipulate the indexed object.
    */
-  ctx.data.byGroupAndType = indexer.byGroupAndType(ctx.data)
+  ctx.data.byGroupAndType = extras.byGroupAndType(ctx.data);
 
   /**
    * Now we have prepared the data, we can proxy to the Themeleon

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "keywords": [
+    "sassdoc-theme"
+  ],
+
   "dependencies": {
     "extend": "^1.0",
     "swig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "extend": "^1.0",
     "swig": "^1.4.0",
     "themeleon": "^3.0.0",
-    "sassdoc-filter": "^2.0.0",
-    "sassdoc-indexer": "^2.0.0"
+    "sassdoc-extras": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "dependencies": {
-    "extend": "1.*",
-    "swig": "1.3.*",
-    "themeleon": "0.*",
-    "themeleon-swig": "0.*",
-    "sassdoc-filter": "^1.0.0",
-    "sassdoc-indexer": "^1.0.0"
+    "extend": "^1.0",
+    "swig": "^1.4.0",
+    "themeleon": "^3.0.0",
+    "sassdoc-filter": "^2.0.0",
+    "sassdoc-indexer": "^2.0.0"
   }
 }


### PR DESCRIPTION
This theme doesn't work at all in 2019. Here I'm upgrading to sassdoc-extras thanks to @valeriangalliat's commits to the develop branch, plus adding a starter `default.json` file so that the theme actually builds.